### PR TITLE
Adf check environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ The system requires AIRA Compiled Code Sets (`Compiled.xml`).
 * **Management:** Handled by `load-codebase.sh`.
 * **Version:** Determined by the commit SHA in `codebase-compiled-xml.sha`.
 
+### Keeping ADF store on Application Upgrade
+The application has the ability to check the Encryption and Compatibility of the ADF's and automatically upgrade them.
+ - This step can be expensive in memory 
+ - It is only important to run after an application upgrade.
+
+Running the app with the Environment Variable
+```QDAR_ADF_STORE_UPGRADE_CHECK=true``` performs the upgrade.
+
 ## Build Instructions
 
 ### Docker Build (Recommended)
@@ -129,3 +137,4 @@ The application relies on the AIRA `Compiled.xml` file for standard code sets an
 
 * **Versioning:** The version is determined by the specific commit hash found in the `codebase-compiled-xml.sha` file.
 * **Execution:** The script downloads the `Compiled.xml` file from the remote `immregistries/codebase` repository at that specific commit and installs it into the resource directories for both the CLI (`darq-cli-app`) and WebApp (`darq-webapp`).
+

--- a/darq-webapp/darq-app/src/main/java/gov/nist/healthcare/iz/darq/boot/ADFStore.java
+++ b/darq-webapp/darq-app/src/main/java/gov/nist/healthcare/iz/darq/boot/ADFStore.java
@@ -30,6 +30,8 @@ public class ADFStore {
 	CryptoKey adfKeys;
 	@Value("#{environment.QDAR_STORE}")
 	private String QDAR_STORE;
+	@Value("#{environment.QDAR_ADF_STORE_UPGRADE_CHECK ?: false}")
+	private boolean QDAR_ADF_STORE_UPGRADE_CHECK;
 	@Autowired
 	TransformerService transformerService;
 	@Autowired
@@ -54,48 +56,53 @@ public class ADFStore {
 			int nb = Objects.requireNonNull(f.list()).length;
 			System.out.println(" * Store Directory Exists");
 			System.out.println(" * Contains " + nb + " ADFs");
-			AtomicInteger i = new AtomicInteger();
-			Path storePath = Paths.get(QDAR_STORE);
-			try (Stream<Path> walk = Files.walk(storePath)) {
-				List<String> errors = walk.filter(Files::isDirectory)
-						.filter((path) -> path.compareTo(storePath) != 0)
-						.map((path) -> {
-							System.out.println(" + Checking ADF " + (i.incrementAndGet()) + "/" + nb + " @ " + path.toAbsolutePath());
-							File adf = Paths.get(path.toAbsolutePath().toString(), ADFStorage.ADF_FILENAME).toFile();
-							if(!adf.exists()) {
-								System.out.println(" ! No ADF file ( "+ ADFStorage.ADF_FILENAME +" ) found at " + path.toAbsolutePath());
-								return "No ADF file ( "+ ADFStorage.ADF_FILENAME +" ) found at " + path.toAbsolutePath();
-							}
-							try(ADFReader reader = manager.getADFReader(adf.getAbsolutePath())) {
-								System.out.println(" * Checking ADF encryption key");
-								if(reader.checkADFKey(adfKeys)) {
-									System.out.println(" * Checking ADF Version ("+reader.getVersion()+")");
-									if(!reader.getVersion().equals(supportedVersion)) {
-										System.out.println(" * Converting ADF to " + supportedVersion);
-										reader.read(adfKeys);
-										transformerService.transform(
-												reader.getVersion(),
-												supportedVersion,
-												adfKeys,
-												reader,
-												adf.toPath(),
-												false
-										);
-									}
-								} else {
-									System.out.println(" ! Current ADF KeyPair is not valid from ADF at " + adf.getAbsolutePath());
-									return "Current ADF KeyPair is not valid from ADF at " + adf.getAbsolutePath();
+			if (!QDAR_ADF_STORE_UPGRADE_CHECK) {
+				System.out.println(" * ADF Encryption Key and version checks and conversion disabled");
+				System.out.println(" * Set Environment Variable QDAR_ADF_STORE_UPGRADE_CHECK to true to check and upgrade ADFs");
+			} else {
+				AtomicInteger i = new AtomicInteger();
+				Path storePath = Paths.get(QDAR_STORE);
+				try (Stream<Path> walk = Files.walk(storePath)) {
+					List<String> errors = walk.filter(Files::isDirectory)
+							.filter((path) -> path.compareTo(storePath) != 0)
+							.map((path) -> {
+								System.out.println(" + Checking ADF " + (i.incrementAndGet()) + "/" + nb + " @ " + path.toAbsolutePath());
+								File adf = Paths.get(path.toAbsolutePath().toString(), ADFStorage.ADF_FILENAME).toFile();
+								if(!adf.exists()) {
+									System.out.println(" ! No ADF file ( "+ ADFStorage.ADF_FILENAME +" ) found at " + path.toAbsolutePath());
+									return "No ADF file ( "+ ADFStorage.ADF_FILENAME +" ) found at " + path.toAbsolutePath();
 								}
-								System.out.println(" * All Checks Pass ");
-								return null;
-							} catch (Exception e) {
-								e.printStackTrace();
-								System.out.println(" ! Exception encountered while checking ADF at " + adf.getAbsolutePath() + " " + e.getMessage());
-								return "Exception encountered while checking ADF at " + adf.getAbsolutePath() + " " + e.getMessage();
-							}
-						}).filter(Objects::nonNull).collect(Collectors.toList());
-				if(errors.size() > 0) {
-					throw new Exception("[QDAR_ADF_STORE_CHECK] " + String.join(", ", errors));
+								try(ADFReader reader = manager.getADFReader(adf.getAbsolutePath())) {
+									System.out.println(" * Checking ADF encryption key");
+									if(reader.checkADFKey(adfKeys)) {
+										System.out.println(" * Checking ADF Version ("+reader.getVersion()+")");
+										if(!reader.getVersion().equals(supportedVersion)) {
+											System.out.println(" * Converting ADF to " + supportedVersion);
+											reader.read(adfKeys);
+											transformerService.transform(
+													reader.getVersion(),
+													supportedVersion,
+													adfKeys,
+													reader,
+													adf.toPath(),
+													false
+											);
+										}
+									} else {
+										System.out.println(" ! Current ADF KeyPair is not valid from ADF at " + adf.getAbsolutePath());
+										return "Current ADF KeyPair is not valid from ADF at " + adf.getAbsolutePath();
+									}
+									System.out.println(" * All Checks Pass ");
+									return null;
+								} catch (Exception e) {
+									e.printStackTrace();
+									System.out.println(" ! Exception encountered while checking ADF at " + adf.getAbsolutePath() + " " + e.getMessage());
+									return "Exception encountered while checking ADF at " + adf.getAbsolutePath() + " " + e.getMessage();
+								}
+							}).filter(Objects::nonNull).collect(Collectors.toList());
+					if(errors.size() > 0) {
+						throw new Exception("[QDAR_ADF_STORE_CHECK] " + String.join(", ", errors));
+					}
 				}
 			}
 		}

--- a/darq-webapp/darq-app/src/main/java/gov/nist/healthcare/iz/darq/boot/ADFStore.java
+++ b/darq-webapp/darq-app/src/main/java/gov/nist/healthcare/iz/darq/boot/ADFStore.java
@@ -30,7 +30,7 @@ public class ADFStore {
 	CryptoKey adfKeys;
 	@Value("#{environment.QDAR_STORE}")
 	private String QDAR_STORE;
-	@Value("#{environment.QDAR_ADF_STORE_UPGRADE_CHECK ?: false}")
+	@Value("#{environment.QDAR_ADF_STORE_UPGRADE_CHECK:false}")
 	private boolean QDAR_ADF_STORE_UPGRADE_CHECK;
 	@Autowired
 	TransformerService transformerService;


### PR DESCRIPTION
Introduced new environment variable ```QDAR_ADF_STORE_UPGRADE_CHECK``` to toggle ADF Store upgrade scripts, set to false by default